### PR TITLE
add update resources feature

### DIFF
--- a/api/mainconfig_types.go
+++ b/api/mainconfig_types.go
@@ -29,6 +29,6 @@ type MainConfig struct {
 type MainConfigSpec struct{}
 
 // todo generate
-func (c *MainConfig) DeepCopy() cl.ResourceObject {
+func (c *MainConfig) DeepCopy() *MainConfig {
 	return cl.DeepCopyStruct(c).(*MainConfig)
 }

--- a/api/mainconfig_types.go
+++ b/api/mainconfig_types.go
@@ -1,6 +1,8 @@
 package api
 
-import cl "warp-server/pkg/controlloop"
+import (
+	cl "warp-server/pkg/controlloop"
+)
 
 const (
 	VPNConnectedCondition     = "VPNConnected"
@@ -25,3 +27,8 @@ type MainConfig struct {
 }
 
 type MainConfigSpec struct{}
+
+// todo generate
+func (c *MainConfig) DeepCopy() cl.ResourceObject {
+	return cl.DeepCopyStruct(c).(*MainConfig)
+}

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -59,7 +59,7 @@ func main() {
 		tunnelService,
 	)
 
-	mainLoop := cl.New(mainController, cl.WithLogger(log.NewLogger()))
+	mainLoop := cl.New[*api.MainConfig](mainController, cl.WithLogger(log.NewLogger()))
 	mainLoop.Storage.Add(mc)
 	mainLoop.Run()
 	log.Info().Msg("Main", "Start run main loop")

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -33,7 +33,7 @@ func main() {
 		panic(fmt.Errorf("Error loading config: %s ", err))
 	}
 
-	newResource := cl.NewResource()
+	newResource := cl.NewResource("newResource")
 	mc := &api.MainConfig{
 		Resource: *newResource,
 		Spec:     api.MainConfigSpec{},

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -60,7 +60,7 @@ func main() {
 	)
 
 	mainLoop := cl.New(mainController, cl.WithLogger(log.NewLogger()))
-	mainLoop.Queue.AddResource(mc)
+	mainLoop.Storage.Add(mc)
 	mainLoop.Run()
 	log.Info().Msg("Main", "Start run main loop")
 

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -59,7 +59,7 @@ func main() {
 		tunnelService,
 	)
 
-	mainLoop := cl.New[*api.MainConfig](mainController, cl.WithLogger(log.NewLogger()))
+	mainLoop, _ := cl.New[*api.MainConfig](mainController, cl.WithLogger(log.NewLogger()))
 	mainLoop.Storage.Add(mc)
 	mainLoop.Run()
 	log.Info().Msg("Main", "Start run main loop")

--- a/internal/controllers/main_controller.go
+++ b/internal/controllers/main_controller.go
@@ -34,11 +34,8 @@ type MainReconcile struct {
 	tunnelService  *tunnel.Service
 }
 
-func (r *MainReconcile) Reconcile(ctx context.Context, object cl.ResourceObject) (cl.Result, error) {
-	config, ok := object.(*api.MainConfig)
-	if !ok {
-		panic("not cast object to MainConfig error")
-	}
+func (r *MainReconcile) Reconcile(ctx context.Context, object *api.MainConfig) (cl.Result, error) {
+	config := object
 
 	defer func() {
 		r.conditionsChan <- config.GetConditions()

--- a/internal/controllers/main_controller.go
+++ b/internal/controllers/main_controller.go
@@ -44,7 +44,7 @@ func (r *MainReconcile) Reconcile(ctx context.Context, object cl.ResourceObject)
 		r.conditionsChan <- config.GetConditions()
 	}()
 
-	if config.KillTimestamp() != "" {
+	if config.GetKillTimestamp() != "" {
 		return r.reconcileKill(ctx, config)
 	}
 

--- a/pkg/assertions/types.go
+++ b/pkg/assertions/types.go
@@ -1,0 +1,17 @@
+package assertions
+
+import "reflect"
+
+func TypeOf[T any]() reflect.Type {
+	var t T
+	return reflect.TypeOf(t)
+}
+
+func As[T any](raw interface{}) (T, bool) {
+	var zero T
+	rv := reflect.ValueOf(raw)
+	if rv.Type().AssignableTo(reflect.TypeOf(zero)) {
+		return rv.Interface().(T), true
+	}
+	return zero, false
+}

--- a/pkg/assertions/types.go
+++ b/pkg/assertions/types.go
@@ -8,10 +8,6 @@ func TypeOf[T any]() reflect.Type {
 }
 
 func As[T any](raw interface{}) (T, bool) {
-	var zero T
-	rv := reflect.ValueOf(raw)
-	if rv.Type().AssignableTo(reflect.TypeOf(zero)) {
-		return rv.Interface().(T), true
-	}
-	return zero, false
+	v, ok := raw.(T)
+	return v, ok
 }

--- a/pkg/controlloop/control_loop.go
+++ b/pkg/controlloop/control_loop.go
@@ -13,10 +13,14 @@ type Result struct {
 type ResourceObject interface {
 	GetConditions() []Condition
 	GetCondition(name string) (Condition, bool)
+	GetGeneration() int64
+	IncGeneration()
 	SetKillTimestamp(time time.Time)
-	KillTimestamp() string
+	GetKillTimestamp() string
 	SetDeletionTimestamp(time.Time)
-	DeletionTimestamp() string
+	GetDeletionTimestamp() string
+	GetName() ObjectKey
+	DeepCopy() ResourceObject
 }
 
 type Reconcile interface {

--- a/pkg/controlloop/control_loop.go
+++ b/pkg/controlloop/control_loop.go
@@ -10,7 +10,7 @@ type Result struct {
 	Requeue      bool
 }
 
-type ResourceObject interface {
+type ResourceObject[T any] interface {
 	GetConditions() []Condition
 	GetCondition(name string) (Condition, bool)
 	GetGeneration() int64
@@ -20,9 +20,9 @@ type ResourceObject interface {
 	SetDeletionTimestamp(time.Time)
 	GetDeletionTimestamp() string
 	GetName() ObjectKey
-	DeepCopy() ResourceObject
+	DeepCopy() T
 }
 
-type Reconcile interface {
-	Reconcile(context.Context, ResourceObject) (Result, error)
+type Reconcile[T ResourceObject[T]] interface {
+	Reconcile(context.Context, T) (Result, error)
 }

--- a/pkg/controlloop/deep_copy.go
+++ b/pkg/controlloop/deep_copy.go
@@ -9,7 +9,7 @@ func DeepCopyStruct(src interface{}) interface{} {
 	if srcVal.Kind() != reflect.Ptr || srcVal.Elem().Kind() != reflect.Struct {
 		panic("DeepCopyStructPtr: input must be a pointer to a struct")
 	}
-	// Вызов deepCopyValue для обработки указателя (case reflect.Ptr вернёт новый указатель)
+	// Вызов deepCopyValue для обработки указателя (case assertions.Ptr вернёт новый указатель)
 	return deepCopyValue(srcVal).Interface()
 }
 

--- a/pkg/controlloop/deep_copy.go
+++ b/pkg/controlloop/deep_copy.go
@@ -1,0 +1,78 @@
+package controlloop
+
+import "reflect"
+
+// DeepCopyStructPtr принимает указатель на структуру (вход через interface{}),
+// проверяет тип и возвращает указатель на глубокую копию этой структуры.
+func DeepCopyStruct(src interface{}) interface{} {
+	srcVal := reflect.ValueOf(src)
+	if srcVal.Kind() != reflect.Ptr || srcVal.Elem().Kind() != reflect.Struct {
+		panic("DeepCopyStructPtr: input must be a pointer to a struct")
+	}
+	// Вызов deepCopyValue для обработки указателя (case reflect.Ptr вернёт новый указатель)
+	return deepCopyValue(srcVal).Interface()
+}
+
+// deepCopyValue рекурсивно копирует значение с учётом его вида (kind).
+func deepCopyValue(val reflect.Value) reflect.Value {
+	switch val.Kind() {
+	case reflect.Ptr:
+		if val.IsNil() {
+			return reflect.Zero(val.Type())
+		}
+		// Создаём новый указатель того же типа, копируя значение, на которое он указывает.
+		copyPtr := reflect.New(val.Elem().Type())
+		copyPtr.Elem().Set(deepCopyValue(val.Elem()))
+		return copyPtr
+
+	case reflect.Interface:
+		if val.IsNil() {
+			return reflect.Zero(val.Type())
+		}
+		return deepCopyValue(val.Elem())
+
+	case reflect.Struct:
+		cp := reflect.New(val.Type()).Elem()
+		for i := 0; i < val.NumField(); i++ {
+			field := val.Field(i)
+			// Если поле может быть установлено, делаем глубокую копию, иначе просто копируем.
+			if cp.Field(i).CanSet() {
+				cp.Field(i).Set(deepCopyValue(field))
+			} else {
+				cp.Field(i).Set(field)
+			}
+		}
+		return cp
+
+	case reflect.Slice:
+		if val.IsNil() {
+			return reflect.Zero(val.Type())
+		}
+		cp := reflect.MakeSlice(val.Type(), val.Len(), val.Cap())
+		for i := 0; i < val.Len(); i++ {
+			cp.Index(i).Set(deepCopyValue(val.Index(i)))
+		}
+		return cp
+
+	case reflect.Array:
+		cp := reflect.New(val.Type()).Elem()
+		for i := 0; i < val.Len(); i++ {
+			cp.Index(i).Set(deepCopyValue(val.Index(i)))
+		}
+		return cp
+
+	case reflect.Map:
+		if val.IsNil() {
+			return reflect.Zero(val.Type())
+		}
+		cp := reflect.MakeMapWithSize(val.Type(), val.Len())
+		for _, key := range val.MapKeys() {
+			cp.SetMapIndex(deepCopyValue(key), deepCopyValue(val.MapIndex(key)))
+		}
+		return cp
+
+	// Для примитивных типов (чисел, строк, bool и т.д.) достаточно вернуть значение, так как оно уже копируется по значению.
+	default:
+		return val
+	}
+}

--- a/pkg/controlloop/erros.go
+++ b/pkg/controlloop/erros.go
@@ -1,0 +1,6 @@
+package controlloop
+
+import "errors"
+
+var KetNotExist = errors.New("key does't exist")
+var AlreadyUpdated = errors.New("resource already updated")

--- a/pkg/controlloop/erros.go
+++ b/pkg/controlloop/erros.go
@@ -2,5 +2,5 @@ package controlloop
 
 import "errors"
 
-var KetNotExist = errors.New("key does't exist")
+var KeyNotExist = errors.New("key does't exist")
 var AlreadyUpdated = errors.New("resource already updated")

--- a/pkg/controlloop/options.go
+++ b/pkg/controlloop/options.go
@@ -3,7 +3,7 @@ package controlloop
 type opts struct {
 	logger      Logger
 	concurrency int
-	storages    *Storages
+	storages    *StorageSet
 }
 
 type ClOption func(*opts)
@@ -20,7 +20,7 @@ func WithConcurrentReconciles(count int) ClOption {
 	}
 }
 
-func WithStorages(sr *Storages) ClOption {
+func WithStorageSet(sr *StorageSet) ClOption {
 	return func(o *opts) {
 		o.storages = sr
 	}

--- a/pkg/controlloop/options.go
+++ b/pkg/controlloop/options.go
@@ -3,6 +3,7 @@ package controlloop
 type opts struct {
 	logger      Logger
 	concurrency int
+	storages    *Storages
 }
 
 type ClOption func(*opts)
@@ -16,5 +17,11 @@ func WithLogger(logger Logger) ClOption {
 func WithConcurrentReconciles(count int) ClOption {
 	return func(o *opts) {
 		o.concurrency = count
+	}
+}
+
+func WithStorages(sr *Storages) ClOption {
+	return func(o *opts) {
+		o.storages = sr
 	}
 }

--- a/pkg/controlloop/queue.go
+++ b/pkg/controlloop/queue.go
@@ -6,53 +6,53 @@ import (
 	"time"
 )
 
-type Queue[t comparable] struct {
+type Queue[T ResourceObject[T]] struct {
 	queue        workqueue.TypedRateLimitingInterface[ObjectKey]
-	existedItems map[ObjectKey]ResourceObject
+	existedItems map[ObjectKey]ResourceObject[T]
 	m            *sync.RWMutex
 }
 
-func NewQueue() *Queue[ResourceObject] {
+func NewQueue[T ResourceObject[T]]() *Queue[T] {
 	rateLimitingConfig := workqueue.TypedRateLimitingQueueConfig[ObjectKey]{}
 	rateLimitingConfig.DelayingQueue = workqueue.NewTypedDelayingQueue[ObjectKey]()
 	queue := workqueue.NewTypedRateLimitingQueueWithConfig[ObjectKey](workqueue.NewTypedMaxOfRateLimiter[ObjectKey](), rateLimitingConfig)
-	return &Queue[ResourceObject]{queue: queue, existedItems: make(map[ObjectKey]ResourceObject), m: &sync.RWMutex{}}
+	return &Queue[T]{queue: queue, existedItems: make(map[ObjectKey]ResourceObject[T]), m: &sync.RWMutex{}}
 }
 
-func (q *Queue[t]) getExistedItems() map[ObjectKey]ResourceObject {
+func (q *Queue[T]) getExistedItems() map[ObjectKey]ResourceObject[T] {
 	q.m.RLock()
 	defer q.m.RUnlock()
 	return q.existedItems
 }
 
-func (q *Queue[t]) len() int {
+func (q *Queue[T]) len() int {
 	q.m.RLock()
 	defer q.m.RUnlock()
 	return len(q.existedItems)
 }
 
-func (q *Queue[t]) add(item ResourceObject) {
+func (q *Queue[T]) add(item ResourceObject[T]) {
 	q.m.Lock()
 	defer q.m.Unlock()
 	q.existedItems[item.GetName()] = item
 	q.queue.Add(item.GetName())
 }
 
-func (q *Queue[t]) finalize(item ResourceObject) {
+func (q *Queue[T]) finalize(item ResourceObject[T]) {
 	q.m.Lock()
 	defer q.m.Unlock()
 	delete(q.existedItems, item.GetName())
 }
 
-func (q *Queue[t]) done(item ResourceObject) {
+func (q *Queue[T]) done(item ResourceObject[T]) {
 	q.queue.Done(item.GetName())
 }
 
-func (q *Queue[t]) addAfter(item ResourceObject, duration time.Duration) {
+func (q *Queue[T]) addAfter(item ResourceObject[T], duration time.Duration) {
 	q.queue.AddAfter(item.GetName(), duration)
 }
 
-func (q *Queue[t]) addRateLimited(item ResourceObject) {
+func (q *Queue[T]) addRateLimited(item ResourceObject[T]) {
 	q.queue.AddRateLimited(item.GetName())
 }
 

--- a/pkg/controlloop/queue.go
+++ b/pkg/controlloop/queue.go
@@ -7,19 +7,19 @@ import (
 )
 
 type Queue[t comparable] struct {
-	queue        workqueue.TypedRateLimitingInterface[ResourceObject]
-	existedItems map[ResourceObject]struct{}
+	queue        workqueue.TypedRateLimitingInterface[ObjectKey]
+	existedItems map[ObjectKey]ResourceObject
 	m            *sync.RWMutex
 }
 
 func NewQueue() *Queue[ResourceObject] {
-	rateLimitingConfig := workqueue.TypedRateLimitingQueueConfig[ResourceObject]{}
-	rateLimitingConfig.DelayingQueue = workqueue.NewTypedDelayingQueue[ResourceObject]()
-	queue := workqueue.NewTypedRateLimitingQueueWithConfig[ResourceObject](workqueue.NewTypedMaxOfRateLimiter[ResourceObject](), rateLimitingConfig)
-	return &Queue[ResourceObject]{queue: queue, existedItems: make(map[ResourceObject]struct{}), m: &sync.RWMutex{}}
+	rateLimitingConfig := workqueue.TypedRateLimitingQueueConfig[ObjectKey]{}
+	rateLimitingConfig.DelayingQueue = workqueue.NewTypedDelayingQueue[ObjectKey]()
+	queue := workqueue.NewTypedRateLimitingQueueWithConfig[ObjectKey](workqueue.NewTypedMaxOfRateLimiter[ObjectKey](), rateLimitingConfig)
+	return &Queue[ResourceObject]{queue: queue, existedItems: make(map[ObjectKey]ResourceObject), m: &sync.RWMutex{}}
 }
 
-func (q *Queue[t]) getExistedItems() map[ResourceObject]struct{} {
+func (q *Queue[t]) getExistedItems() map[ObjectKey]ResourceObject {
 	q.m.RLock()
 	defer q.m.RUnlock()
 	return q.existedItems
@@ -34,32 +34,64 @@ func (q *Queue[t]) len() int {
 func (q *Queue[t]) AddResource(item ResourceObject) {
 	q.m.Lock()
 	defer q.m.Unlock()
-	q.existedItems[item] = struct{}{}
-	q.queue.Add(item)
+	q.existedItems[item.GetName()] = item
+	q.queue.Add(item.GetName())
+}
+
+func (q *Queue[t]) GetResource(item ResourceObject) ResourceObject {
+	q.m.RLock()
+	defer q.m.RUnlock()
+	val, exist := q.existedItems[item.GetName()]
+	if !exist {
+		return nil
+	}
+	return val.DeepCopy()
+}
+
+func (q *Queue[t]) Update(item ResourceObject) error {
+	q.m.Lock()
+	defer q.m.Unlock()
+	curr, exist := q.existedItems[item.GetName()]
+	if !exist {
+		return KetNotExist
+	}
+	if curr.GetGeneration() > item.GetGeneration() {
+		return AlreadyUpdated
+	}
+	curr.IncGeneration()
+	q.existedItems[item.GetName()] = item
+	q.queue.Add(item.GetName())
+	return nil
 }
 
 func (q *Queue[t]) add(item ResourceObject) {
-	q.queue.Add(item)
+	q.queue.Add(item.GetName())
 }
 
 func (q *Queue[t]) finalize(item ResourceObject) {
 	q.m.Lock()
 	defer q.m.Unlock()
-	delete(q.existedItems, item)
+	delete(q.existedItems, item.GetName())
 }
 
 func (q *Queue[t]) done(item ResourceObject) {
-	q.queue.Done(item)
+	q.queue.Done(item.GetName())
 }
 
 func (q *Queue[t]) addAfter(item ResourceObject, duration time.Duration) {
-	q.queue.AddAfter(item, duration)
+	q.queue.AddAfter(item.GetName(), duration)
 }
 
 func (q *Queue[t]) addRateLimited(item ResourceObject) {
-	q.queue.AddRateLimited(item)
+	q.queue.AddRateLimited(item.GetName())
 }
 
 func (q *Queue[t]) get() (ResourceObject, bool) {
-	return q.queue.Get()
+	q.m.Lock()
+	defer q.m.Unlock()
+	name, shutdown := q.queue.Get()
+	if shutdown {
+		return nil, true
+	}
+	return q.existedItems[name].DeepCopy(), false
 }

--- a/pkg/controlloop/queue.go
+++ b/pkg/controlloop/queue.go
@@ -57,8 +57,6 @@ func (q *Queue[T]) addRateLimited(item ResourceObject[T]) {
 }
 
 func (q *Queue[t]) get() (ObjectKey, bool) {
-	q.m.Lock()
-	defer q.m.Unlock()
 	name, shutdown := q.queue.Get()
 	if shutdown {
 		return "", true

--- a/pkg/controlloop/queue.go
+++ b/pkg/controlloop/queue.go
@@ -15,7 +15,7 @@ type Queue[T ResourceObject[T]] struct {
 func NewQueue[T ResourceObject[T]]() *Queue[T] {
 	rateLimitingConfig := workqueue.TypedRateLimitingQueueConfig[ObjectKey]{}
 	rateLimitingConfig.DelayingQueue = workqueue.NewTypedDelayingQueue[ObjectKey]()
-	queue := workqueue.NewTypedRateLimitingQueueWithConfig[ObjectKey](workqueue.NewTypedMaxOfRateLimiter[ObjectKey](), rateLimitingConfig)
+	queue := workqueue.NewTypedRateLimitingQueueWithConfig[ObjectKey](workqueue.DefaultTypedControllerRateLimiter[ObjectKey](), rateLimitingConfig)
 	return &Queue[T]{queue: queue, existedItems: make(map[ObjectKey]ResourceObject[T]), m: &sync.RWMutex{}}
 }
 

--- a/pkg/controlloop/resource.go
+++ b/pkg/controlloop/resource.go
@@ -1,17 +1,18 @@
 package controlloop
 
 import (
-	"sync"
+	"sync/atomic"
 	"time"
 )
 
+type ObjectKey = string
+
 type Resource struct {
-	conditions        []Condition
-	m                 *sync.RWMutex
-	killTimestamp     string
-	killMutex         *sync.Mutex
-	deletionMutex     *sync.Mutex
-	deletionTimestamp string
+	Conditions        []Condition
+	KillTimestamp     string
+	DeletionTimestamp string
+	Generation        int64
+	Name              ObjectKey
 }
 
 type Condition struct {
@@ -21,47 +22,39 @@ type Condition struct {
 	Message string
 }
 
-func NewResource() *Resource {
-	return &Resource{m: &sync.RWMutex{}, killMutex: &sync.Mutex{}}
+func NewResource(name ObjectKey) *Resource {
+	return &Resource{Name: name}
 }
 
 func (r *Resource) SetKillTimestamp(time time.Time) {
-	if r.killMutex == nil {
-		return
-	}
-	r.killMutex.Lock()
-	defer r.killMutex.Unlock()
-	if r.killTimestamp == "" {
-		r.killTimestamp = time.Format("2006-01-02 15:04:05")
+	if r.KillTimestamp == "" {
+		r.KillTimestamp = time.Format("2006-01-02 15:04:05")
 	}
 }
 
-func (r *Resource) KillTimestamp() string {
-	r.killMutex.Lock()
-	defer r.killMutex.Unlock()
-	return r.killTimestamp
+func (r *Resource) GetKillTimestamp() string {
+	return r.KillTimestamp
 }
 
 func (r *Resource) SetDeletionTimestamp(time time.Time) {
-	if r.deletionMutex == nil {
-		return
-	}
-	r.deletionMutex.Lock()
-	defer r.deletionMutex.Unlock()
-	if r.deletionTimestamp == "" {
-		r.deletionTimestamp = time.Format("2006-01-02 15:04:05")
+	if r.DeletionTimestamp == "" {
+		r.DeletionTimestamp = time.Format("2006-01-02 15:04:05")
 	}
 }
 
-func (r *Resource) DeletionTimestamp() string {
-	r.deletionMutex.Lock()
-	defer r.deletionMutex.Unlock()
-	return r.deletionTimestamp
+func (r *Resource) GetDeletionTimestamp() string {
+	return r.DeletionTimestamp
+}
+
+func (r *Resource) IncGeneration() {
+	atomic.AddInt64(&r.Generation, 1)
+}
+
+func (r *Resource) GetGeneration() int64 {
+	return atomic.LoadInt64(&r.Generation)
 }
 
 func (r *Resource) setCondition(name, status, reason, message string) {
-	r.m.Lock()
-	defer r.m.Unlock()
 	exist := func(slice []Condition, name string) bool {
 		for _, item := range slice {
 			if item.Type == name {
@@ -70,23 +63,25 @@ func (r *Resource) setCondition(name, status, reason, message string) {
 		}
 		return false
 	}
-	if exist(r.conditions, name) {
-		for i := range r.conditions {
-			if r.conditions[i].Type == name {
-				r.conditions[i].Reason = reason
-				r.conditions[i].Message = message
-				r.conditions[i].Status = status
+	if exist(r.Conditions, name) {
+		for i := range r.Conditions {
+			if r.Conditions[i].Type == name {
+				r.Conditions[i].Reason = reason
+				r.Conditions[i].Message = message
+				r.Conditions[i].Status = status
 			}
 		}
 		return
 	}
-	r.conditions = append(r.conditions, Condition{Type: name, Status: status, Reason: reason, Message: message})
+	r.Conditions = append(r.Conditions, Condition{Type: name, Status: status, Reason: reason, Message: message})
 }
 
 func (r *Resource) GetConditions() []Condition {
-	r.m.RLock()
-	defer r.m.RUnlock()
-	return r.conditions
+	return r.Conditions
+}
+
+func (r *Resource) GetName() ObjectKey {
+	return r.Name
 }
 
 func (r *Resource) GetCondition(name string) (Condition, bool) {

--- a/pkg/controlloop/run.go
+++ b/pkg/controlloop/run.go
@@ -20,10 +20,11 @@ type ControlLoop[T ResourceObject[T]] struct {
 	l           Logger
 	concurrency int
 	Storage     Storage[T]
+	storages    *Storages
 	Queue       *Queue[T]
 }
 
-func New[T ResourceObject[T]](r Reconcile[T], options ...ClOption) *ControlLoop[T] {
+func New[T ResourceObject[T]](r Reconcile[T], options ...ClOption) (*ControlLoop[T], Storage[T]) {
 	currentOptions := &opts{}
 	for _, o := range options {
 		o(currentOptions)
@@ -50,7 +51,12 @@ func New[T ResourceObject[T]](r Reconcile[T], options ...ClOption) *ControlLoop[
 	} else {
 		controlLoop.concurrency = 1
 	}
-	return controlLoop
+
+	if currentOptions.storages != nil {
+		controlLoop.storages = currentOptions.storages
+	}
+
+	return controlLoop, controlLoop.Storage
 }
 
 func (cl *ControlLoop[T]) Run() {

--- a/pkg/controlloop/run.go
+++ b/pkg/controlloop/run.go
@@ -107,7 +107,11 @@ func (cl *ControlLoop[T]) Run() {
 			case result.Requeue:
 				cl.Queue.add(object)
 			default:
-				cl.Queue.finalize(object)
+				if object.GetDeletionTimestamp() != "" {
+					cl.Storage.Delete(object)
+				} else {
+					cl.Queue.finalize(object)
+				}
 			}
 
 			cl.Queue.done(object)

--- a/pkg/controlloop/run.go
+++ b/pkg/controlloop/run.go
@@ -20,7 +20,7 @@ type ControlLoop[T ResourceObject[T]] struct {
 	l           Logger
 	concurrency int
 	Storage     Storage[T]
-	storages    *Storages
+	storages    *StorageSet
 	Queue       *Queue[T]
 }
 

--- a/pkg/controlloop/run.go
+++ b/pkg/controlloop/run.go
@@ -83,7 +83,7 @@ func (cl *ControlLoop[T]) Run() {
 			}
 			if err != nil {
 				// object already deleted
-				if errors.Is(err, KetNotExist) {
+				if errors.Is(err, KeyNotExist) {
 					continue
 				}
 			}

--- a/pkg/controlloop/storage.go
+++ b/pkg/controlloop/storage.go
@@ -49,7 +49,7 @@ func (s *MemoryStorage[T]) Update(item T) error {
 	defer s.m.Unlock()
 	curr, exist := s.objects[item.GetName()]
 	if !exist {
-		return KetNotExist
+		return KeyNotExist
 	}
 	if curr.GetGeneration() > item.GetGeneration() {
 		return AlreadyUpdated
@@ -78,7 +78,7 @@ func (s *MemoryStorage[T]) getLast() (T, bool, error) {
 	}
 	// object already deleted
 	if _, exist := s.objects[name]; !exist {
-		return zero, false, KetNotExist
+		return zero, false, KeyNotExist
 	}
 	return s.objects[name].DeepCopy(), false, nil
 }

--- a/pkg/controlloop/storage.go
+++ b/pkg/controlloop/storage.go
@@ -1,0 +1,82 @@
+package controlloop
+
+import (
+	"sync"
+)
+
+type Storage interface {
+	Add(item ResourceObject)
+	Get(item ResourceObject) ResourceObject
+	Update(item ResourceObject) error
+	Delete(item ResourceObject)
+	getLast() (ResourceObject, bool, error)
+}
+
+func NewMemoryStorage(q *Queue[ResourceObject]) *MemoryStorage {
+	return &MemoryStorage{
+		m:       &sync.RWMutex{},
+		Queue:   q,
+		objects: make(map[ObjectKey]ResourceObject),
+	}
+}
+
+type MemoryStorage struct {
+	m       *sync.RWMutex
+	Queue   *Queue[ResourceObject]
+	objects map[ObjectKey]ResourceObject
+}
+
+func (s *MemoryStorage) Add(item ResourceObject) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	s.objects[item.GetName()] = item
+	s.Queue.add(item)
+}
+
+func (s *MemoryStorage) Get(item ResourceObject) ResourceObject {
+	s.m.RLock()
+	defer s.m.RUnlock()
+	val, exist := s.objects[item.GetName()]
+	if !exist {
+		return nil
+	}
+	return val.DeepCopy()
+}
+
+func (s *MemoryStorage) Update(item ResourceObject) error {
+	s.m.Lock()
+	defer s.m.Unlock()
+	curr, exist := s.objects[item.GetName()]
+	if !exist {
+		return KetNotExist
+	}
+	if curr.GetGeneration() > item.GetGeneration() {
+		return AlreadyUpdated
+	}
+	curr.IncGeneration()
+	s.objects[item.GetName()] = item
+	s.Queue.add(item)
+	s.Queue.done(item)
+	return nil
+}
+
+func (s *MemoryStorage) Delete(item ResourceObject) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	s.Queue.finalize(item)
+	delete(s.objects, item.GetName())
+}
+
+func (s *MemoryStorage) getLast() (ResourceObject, bool, error) {
+	s.m.Lock()
+	defer s.m.Unlock()
+	name, shutdown := s.Queue.get()
+	if shutdown {
+		return nil, true, nil
+	}
+	// object already deleted
+	if _, exist := s.objects[name]; !exist {
+		return nil, false, KetNotExist
+	}
+	return s.objects[name].DeepCopy(), false, nil
+}

--- a/pkg/controlloop/storage.go
+++ b/pkg/controlloop/storage.go
@@ -37,7 +37,7 @@ func SetStorage[T ResourceObject[T]](storages *StorageSet, store Storage[T]) {
 type Storage[T ResourceObject[T]] interface {
 	Add(item T)
 	Get(item T) T
-	List(key ObjectKey) []T
+	List() map[ObjectKey]T
 	Update(item T) error
 	Delete(item T)
 	getLast() (T, bool, error)
@@ -75,12 +75,12 @@ func (s *MemoryStorage[T]) Get(item T) T {
 	return val.DeepCopy()
 }
 
-func (s *MemoryStorage[T]) List(key ObjectKey) []T {
+func (s *MemoryStorage[T]) List() map[ObjectKey]T {
 	s.m.RLock()
 	defer s.m.RUnlock()
-	res := make([]T, len(s.objects))
-	for _, v := range s.objects {
-		res = append(res, v.DeepCopy())
+	res := make(map[ObjectKey]T, len(s.objects))
+	for key, v := range s.objects {
+		res[key] = v.DeepCopy()
 	}
 	return res
 }

--- a/pkg/controlloop/storage.go
+++ b/pkg/controlloop/storage.go
@@ -6,18 +6,18 @@ import (
 	"warp-server/pkg/assertions"
 )
 
-type Storages struct {
+type StorageSet struct {
 	mu    sync.RWMutex
 	store map[reflect.Type]interface{}
 }
 
-func NewStorages() *Storages {
-	return &Storages{
+func NewStorageSet() *StorageSet {
+	return &StorageSet{
 		store: make(map[reflect.Type]interface{}),
 	}
 }
 
-func GetStorage[T ResourceObject[T]](storages *Storages) (T, bool) {
+func GetStorage[T ResourceObject[T]](storages *StorageSet) (T, bool) {
 	storages.mu.RLock()
 	defer storages.mu.RUnlock()
 	var zero T
@@ -28,7 +28,7 @@ func GetStorage[T ResourceObject[T]](storages *Storages) (T, bool) {
 	return assertions.As[T](raw)
 }
 
-func SetStorage[T ResourceObject[T]](storages *Storages, store Storage[T]) {
+func SetStorage[T ResourceObject[T]](storages *StorageSet, store Storage[T]) {
 	storages.mu.Lock()
 	defer storages.mu.Unlock()
 	storages.store[assertions.TypeOf[T]()] = store


### PR DESCRIPTION
- The resource object no longer requires locking mechanisms. We are working with deep copy.
- Setting the killtimestamp now works through a forced update.